### PR TITLE
Update for CoreDNS 1.2.5

### DIFF
--- a/plugin/kubernetai/kubernetai.go
+++ b/plugin/kubernetai/kubernetai.go
@@ -67,7 +67,6 @@ func (k8i Kubernetai) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 			// Otherwise write message to client
 			m := nw.Msg
 			state.SizeAndDo(m)
-			m, _ = state.Scrub(m)
 			w.WriteMsg(m)
 
 			return m.Rcode, err


### PR DESCRIPTION
Scrub was changed in CoreDNS 1.2.5, but it's also now redundant so can be removed from ServeDNS in the plugin.

Fixes #14