### PR TITLE
[Bugfix] use the copy of kubernetes.Kubernetes struct to avioid race condition

### DIFF
--- a/plugin/kubernetai/kubernetai.go
+++ b/plugin/kubernetai/kubernetai.go
@@ -40,7 +40,10 @@ func New(zones []string) (Kubernetai, *kubernetes.Kubernetes) {
 // ServeDNS routes requests to the authoritative kubernetes. It implements the plugin.Handler interface.
 func (k8i Kubernetai) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (rcode int, err error) {
 	state := request.Request{W: w, Req: r}
-	for i, k := range k8i.Kubernetes {
+	for i, kube := range k8i.Kubernetes {
+		// use the copy of kubernetes.Kubernetes struct to avioid race condition
+		k := *kube
+
 		zone := plugin.Zones(k.Zones).Matches(state.Name())
 		if zone == "" {
 			continue


### PR DESCRIPTION
CoreDNS will generate goroutines when process DNS request. When use kubernetai, it need to modify `k.Fall` as empty struct before kubernets plugin to process it:
```go
...
oFall := k.Fall
k.Fall = fall.F{}

_, err := k.ServeDNS(ctx, nw, r)

// Restore fallthrough
k.Fall = oFall
...
```

After processing, kubernetai will restore `k.Fall` to original configuration.

Actually, `k.Fall` is reference type, it will be modified by other goroutine in concurrently read and write. Without adding mutex or using own copy, `k.Fall` will finally modify to empty struct instead of original version.