### PR TITLE
Fix fallthrough to the next plugin when suitable

### DIFF
--- a/plugin/kubernetai/kubernetai_test.go
+++ b/plugin/kubernetai/kubernetai_test.go
@@ -166,7 +166,6 @@ func TestKubernetai_AutoPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			k8i := Kubernetai{
 				Zones:          tt.fields.Zones,
-				Next:           tt.fields.Next,
 				Kubernetes:     tt.fields.Kubernetes,
 				autoPathSearch: tt.fields.autoPathSearch,
 				p:              tt.fields.p,

--- a/plugin/kubernetai/setup.go
+++ b/plugin/kubernetai/setup.go
@@ -2,6 +2,7 @@ package kubernetai
 
 import (
 	"context"
+	"errors"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -22,16 +23,22 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error(Name(), err)
 	}
 
+	prev := &kubernetes.Kubernetes{}
 	for _, k := range k8i.Kubernetes {
 		err = k.InitKubeCache(context.Background())
 		if err != nil {
 			return plugin.Error(Name(), err)
 		}
 		k.RegisterKubeCache(c)
+
+		// set Next of the previous kubernetes instance to the current instance
+		prev.Next = k
+		prev = k
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
-		k8i.Next = next
+		// set Next of the last kubernetes instance to the next plugin
+		k8i.Kubernetes[len(k8i.Kubernetes)-1].Next = next
 		return k8i
 	})
 
@@ -44,23 +51,17 @@ func Parse(c *caddy.Controller) (*Kubernetai, error) {
 		autoPathSearch: searchFromResolvConf(),
 		p:              &podHandler{},
 	}
-	var err error
+
 	for c.Next() {
-		var k8s *kubernetes.Kubernetes
-		k8s, err = kubernetes.ParseStanza(c)
+		k8s, err := kubernetes.ParseStanza(c)
 		if err != nil {
 			return nil, err
 		}
 		k8i.Kubernetes = append(k8i.Kubernetes, k8s)
 	}
 
-	for i := 0; i < len(k8i.Kubernetes); i++ {
-		// Copy Fallthough settings from the Kubernetes object
-		k8i.Fall = append(k8i.Fall, k8i.Kubernetes[i].Fall)
-		// for all but last instance, disable fallthrough in the Kubernetes object
-		if i < len(k8i.Kubernetes)-1 {
-			k8i.Kubernetes[i].Fall.Zones = nil
-		}
+	if len(k8i.Kubernetes) == 0 {
+		return nil, errors.New("no kubernetes instance was parsed")
 	}
 
 	return k8i, nil

--- a/plugin/kubernetai/setup_test.go
+++ b/plugin/kubernetai/setup_test.go
@@ -1,0 +1,140 @@
+package kubernetai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/miekg/dns"
+
+	"github.com/coredns/coredns/plugin/kubernetes"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+)
+
+func TestSetup(t *testing.T) {
+	tests := []struct {
+		input     string
+		instances int
+		hasNext   bool
+	}{
+		{
+			input: `
+				kubernetai cluster.local {
+				  endpoint http://192.168.99.100
+				}
+			`,
+			instances: 1,
+			hasNext:   false,
+		},
+		{
+			input: `
+				kubernetai cluster.local {
+				  endpoint http://192.168.99.100
+				}
+				kubernetai assemblage.local {
+				  endpoint http://192.168.99.101
+				}
+			`,
+			instances: 2,
+			hasNext:   false,
+		}, {
+			input: `
+				kubernetai cluster.local {
+				  endpoint http://192.168.99.100
+				}
+				kubernetai assemblage.local {
+				  endpoint http://192.168.99.101
+				}
+				kubernetai conglomeration.local {
+				  endpoint http://192.168.99.102
+				}
+			`,
+			instances: 3,
+			hasNext:   false,
+		},
+		{
+			input: `
+				kubernetai cluster.local {
+				  endpoint http://192.168.99.100
+				}
+			`,
+			instances: 1,
+			hasNext:   true,
+		},
+		{
+			input: `
+				kubernetai cluster.local {
+				  endpoint http://192.168.99.100
+				}
+				kubernetai assemblage.local {
+				  endpoint http://192.168.99.101
+				}
+			`,
+			instances: 2,
+			hasNext:   true,
+		}, {
+			input: `
+				kubernetai cluster.local {
+				  endpoint http://192.168.99.100
+				}
+				kubernetai assemblage.local {
+				  endpoint http://192.168.99.101
+				}
+				kubernetai conglomeration.local {
+				  endpoint http://192.168.99.102
+				}
+			`,
+			instances: 3,
+			hasNext:   true,
+		},
+	}
+
+	for i, test := range tests {
+		var nextHandler plugin.Handler
+		if test.hasNext {
+			handlerFunc := plugin.HandlerFunc(func(_ context.Context, _ dns.ResponseWriter, _ *dns.Msg) (int, error) {
+				return 0, nil
+			})
+			nextHandler = &handlerFunc
+		}
+
+		c := caddy.NewTestController("dns", test.input)
+
+		if err := setup(c); err != nil {
+			t.Fatalf("Test %d: %v", i, err)
+		}
+
+		plugins := dnsserver.GetConfig(c).Plugin
+		if n := len(plugins); n != 1 {
+			t.Fatalf("Test %d: Expected plugin length on controller to be 1, got %d", i, n)
+		}
+
+		handler := plugins[0](nextHandler)
+
+		k8i, ok := handler.(*Kubernetai)
+		if !ok {
+			t.Fatalf("Test %d: Expected handler to be Kubernetai, got %T", i, handler)
+		}
+
+		if n := len(k8i.Kubernetes); n != test.instances {
+			t.Fatalf("Test %d: Expected kubernetes length on handler to be %d, got %d", i, test.instances, n)
+		}
+
+		prev := &kubernetes.Kubernetes{
+			Next: k8i.Kubernetes[0],
+		}
+		for j, k := range k8i.Kubernetes {
+			if prev.Next != k {
+				t.Fatalf("Test %d: Expected kubernetes instance %d to be referencing kubernetes instance %d as next, got %v", i, j-1, j, prev.Next)
+			}
+
+			prev = k
+		}
+
+		if prev.Next != nextHandler {
+			t.Fatalf("Test %d: Expected last kubernetes instance to be referencing nextHandler as next, got %v", i, prev.Next)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #39

This patch disables fallthrough on all internal instances of the Kubernetes plugin and lets Kubernetai handle it instead.

Previously the last Kubernetes plugin instance would try to fallthrough and fail as no `Next` plugin instance was set.